### PR TITLE
Various improvements for the quickbooks-online plugin:

### DIFF
--- a/plugins/quickbooks-online/src/manifest.json
+++ b/plugins/quickbooks-online/src/manifest.json
@@ -32,10 +32,16 @@
       "required": 1
     },
     {
-      "key": "qbIncomeAccountNumber",
-      "label": "Income account number",
-      "description": "Income Account number from QuickBooks",
+      "key": "qbIncomeAccountName",
+      "label": "Income account name",
+      "description": "Income Account name from QuickBooks",
       "required": 1
+    },
+    {
+      "key": "itemNameFormat",
+      "label": "Item Name Format String",
+      "description": "Optional format string to generate QB item names derived from UCRM item type.",
+      "required": 0
     },
     {
       "key": "invoicesFromDate",

--- a/plugins/quickbooks-online/src/src/Data/PluginData.php
+++ b/plugins/quickbooks-online/src/src/Data/PluginData.php
@@ -26,7 +26,7 @@ class PluginData extends UcrmData
     /**
      * @var string
      */
-    public $qbIncomeAccountNumber;
+    public $qbIncomeAccountName;
 
     /**
      * @var string
@@ -87,6 +87,11 @@ class PluginData extends UcrmData
      * @var string
      */
     public $displayedErrors;
+
+    /**
+     * @var string|null
+     */
+    public $itemNameFormat;
 
     /**
      * @var string|null


### PR DESCRIPTION
- Implemented automatic Quickbook Income Account number lookup based on Account Name configured by the user.

New configuration parameter qbIncomeAccountName replaces qbIncomeAccountNumber.

- Implemented clarkraymond's excellent idea of using the type from the UCRM Invoice object (service, product, surcharge, other etc) as the item name for QBO instead of creating thousands of unnecessary items. The QBO item name is generated using a new configuration parameter, "itemNameFormat" which can be typically set to something like "YourWisp %s" or "UCRM %s" to end up with items named "UCRM service", "UCRM product" etc..

- Added preliminary support for Canadian GST (Federal) and Provincial (Quebec) taxes. TaxCodes in the US version of QBO are defined globally for the invoice, whereas in International versions they must be looked up and specified for each item.

- Added qbApiDelay with usleep() before each API call to avoid triggering Intuit's throttling limits for APIs.

See https://developer.intuit.com/app/developer/qbo/docs/develop/rest-api-features#limits-and-throttles

- Improved logging throughout

- Added the possibility of cleanly stopping the plugin during operation (or preventing certain phases from running) by creating "stop files" under data/ directory. The files are "stop" (stops everything), "stopclients" (stops clients being exported), "stopinvoices" (stops invoices being exported), and "stoppayments" (stops payments being exported). This is very handy during development/testing too.

- Fixed incorrect UCRMID pattern for client matching occasionally causing incorrect/multiple matches:

SELECT * FROM Customer WHERE DisplayName LIKE \'%%UCRMID-%d%%\

should be much more robust with LIKE \'%% (UCRMID-%d)%%\

- Changed QBO invoice numbering scheme so that it is based on UCRM Invoice number, a "/" separator and then the internal UCRM invoice ID. This makes it much easier to find/track UCRM invoices in QBO, separately sort them etc..