### PR TITLE
Created new plugin to add payment QR to invoices

### DIFF
--- a/plugins/invoice-qr-code/README.md
+++ b/plugins/invoice-qr-code/README.md
@@ -1,0 +1,15 @@
+# Invoice QR code
+
+This plugin allows you to create invoices with QR codes containing payment information. It will help your customers pay you easily.
+
+# Configuration
+
+This plugin requires you to manually extend your invoice template and add `<img>` tag pointing to public URL of this plugin.
+
+1. go to `System > Plugins`
+2. find `Invoice QR code` plugin and open `See details` link
+3. copy `Public URL` - it looks like `https://ucrm.example.com/_plugins/invoice-csv-export/public.php`  
+4. go to `System > Customization > Invoices`
+5. find your current template - it should be called `Default` if you haven't changed your invoice template yet
+6. click `Clone` icon on the right side and place
+7. new template will be created and you can place `<img src="https://ucrm.example.com/_plugins/invoice-csv-export/public.php?invoiceId={{ invoice.number }}">` anywhere you want in your template 

--- a/plugins/invoice-qr-code/README.md
+++ b/plugins/invoice-qr-code/README.md
@@ -10,4 +10,4 @@ This plugin requires you to manually extend your invoice template and add `<img>
 2. Go to `System > Customization > Invoices`, find your current template and click on the `Edit` button. If you haven't extended the template yet you have to clone the `Default` template using the `Clone` button.
 3. Place the `<img src="pluginsPublicUrlPlaceholder?invoiceId={{ invoice.id }}">` tag anywhere you want in your template. Don't forget to replace `pluginsPublicUrlPlaceholder` with the URL you have copied in the first step.
 
-It's necessary to enable showing bank account on invoices. Otherwise, the plugin will not be working at all. You can do that under `System > Organizations > Your Company, Inc. > Edit > Invoice template` where you can find `Include bank account` toggle.
+It's necessary to enable showing of the bank account on invoices. Otherwise, the plugin will not be working at all. You can do that under `System > Organizations > Your Company, Inc. > Edit > Invoice template` where you can find `Include bank account` toggle.

--- a/plugins/invoice-qr-code/README.md
+++ b/plugins/invoice-qr-code/README.md
@@ -6,10 +6,8 @@ This plugin allows you to create invoices with QR codes containing payment infor
 
 This plugin requires you to manually extend your invoice template and add `<img>` tag pointing to public URL of this plugin.
 
-1. go to `System > Plugins`
-2. find `Invoice QR code` plugin and open `See details` link
-3. copy `Public URL` - it looks like `https://ucrm.example.com/_plugins/invoice-csv-export/public.php`  
-4. go to `System > Customization > Invoices`
-5. find your current template - it should be called `Default` if you haven't changed your invoice template yet
-6. click `Clone` icon on the right side and place
-7. new template will be created and you can place `<img src="https://ucrm.example.com/_plugins/invoice-csv-export/public.php?invoiceId={{ invoice.number }}">` anywhere you want in your template 
+1. Go to `System > Plugins > Invoice QR code > See details` and copy `Public URL` which should look like `https://ucrm.example.com/_plugins/invoice-csv-export/public.php`.
+2. Go to `System > Customization > Invoices`, find your current template and click on the `Edit` button. If you haven't extended the template yet you have to clone the `Default` template using the `Clone` button.
+3. Place the `<img src="pluginsPublicUrlPlaceholder?invoiceId={{ invoice.id }}">` tag anywhere you want in your template. Don't forget to replace `pluginsPublicUrlPlaceholder` with the URL you have copied in the first step.
+
+It's necessary to enable showing bank account on invoices. Otherwise, the plugin will not be working at all. You can do that under `System > Organizations > Your Company, Inc. > Edit > Invoice template` where you can find `Include bank account` toggle.

--- a/plugins/invoice-qr-code/README.md
+++ b/plugins/invoice-qr-code/README.md
@@ -8,6 +8,6 @@ This plugin requires you to manually extend your invoice template and add `<img>
 
 1. Go to `System > Plugins > Invoice QR code > See details` and copy `Public URL` which should look like `https://ucrm.example.com/_plugins/invoice-csv-export/public.php`.
 2. Go to `System > Customization > Invoices`, find your current template and click on the `Edit` button. If you haven't extended the template yet you have to clone the `Default` template using the `Clone` button.
-3. Place the `<img src="pluginsPublicUrlPlaceholder?invoiceId={{ invoice.id }}">` tag anywhere you want in your template. Don't forget to replace `pluginsPublicUrlPlaceholder` with the URL you have copied in the first step.
+3. Place the `<img src="pluginsPublicUrlPlaceholder?organizationCountry={{ organization.country }}&organizationName={{ organization.name }}&bankAccount={{ organization.bankAccount }}&invoiceNumber={{ invoice.number }}&amountDue={{ totals.amountDue }}&dueDate={{ invoice.dueDate }}">` tag anywhere you want in your template. Don't forget to replace `pluginsPublicUrlPlaceholder` with the URL you have copied in the first step.
 
 It's necessary to enable showing of the bank account on invoices. Otherwise, the plugin will not be working at all. You can do that under `System > Organizations > Your Company, Inc. > Edit > Invoice template` where you can find `Include bank account` toggle.

--- a/plugins/invoice-qr-code/src/.gitignore
+++ b/plugins/invoice-qr-code/src/.gitignore
@@ -1,0 +1,3 @@
+/ucrm.json
+data/plugin.log
+vendor/

--- a/plugins/invoice-qr-code/src/classes/CountryConverter.php
+++ b/plugins/invoice-qr-code/src/classes/CountryConverter.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use InvalidArgumentException;
 use Ubnt\UcrmPluginSdk\Service\UcrmApi;
 
 class CountryConverter
@@ -17,15 +18,15 @@ class CountryConverter
         $this->ucrmApi = $ucrmApi;
     }
 
-    public function convertUcrmIdToISO(int $urmCountryId): ?string
+    public function convertCountryNameToISO(string $countryName): ?string
     {
         $this->countriesCollectionCache = $this->countriesCollectionCache ?? $this->ucrmApi->get('countries');
         foreach ($this->countriesCollectionCache as $country) {
-            if ((int)$country['id'] === $urmCountryId) {
+            if ($country['name'] === $countryName) {
                 return $country['code'];
             }
         }
 
-        return null;
+        throw new InvalidArgumentException("Country '{$countryName}' was not found in database.");
     }
 }

--- a/plugins/invoice-qr-code/src/classes/CountryConverter.php
+++ b/plugins/invoice-qr-code/src/classes/CountryConverter.php
@@ -19,8 +19,8 @@ class CountryConverter
 
     public function convertUcrmIdToISO(int $urmCountryId): ?string
     {
-        $countriesCollection = $this->countriesCollectionCache ?? $this->ucrmApi->get('countries');
-        foreach ($countriesCollection as $country) {
+        $this->countriesCollectionCache = $this->countriesCollectionCache ?? $this->ucrmApi->get('countries');
+        foreach ($this->countriesCollectionCache as $country) {
             if ((int)$country['id'] === $urmCountryId) {
                 return $country['code'];
             }

--- a/plugins/invoice-qr-code/src/classes/CountryConverter.php
+++ b/plugins/invoice-qr-code/src/classes/CountryConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App;
+
+use Ubnt\UcrmPluginSdk\Service\UcrmApi;
+
+class CountryConverter
+{
+    /** @var UcrmApi */
+    private $ucrmApi;
+
+    /** @var array */
+    private $countriesCollectionCache;
+
+    public function __construct($ucrmApi)
+    {
+        $this->ucrmApi = $ucrmApi;
+    }
+
+    public function convertUcrmIdToISO(int $urmCountryId): ?string
+    {
+        $countriesCollection = $this->countriesCollectionCache ?? $this->ucrmApi->get('countries');
+        foreach ($countriesCollection as $country) {
+            if ((int)$country['id'] === $urmCountryId) {
+                return $country['code'];
+            }
+        }
+
+        return null;
+    }
+}

--- a/plugins/invoice-qr-code/src/classes/Http.php
+++ b/plugins/invoice-qr-code/src/classes/Http.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+class Http
+{
+    public static function badRequest(): void
+    {
+        if (! headers_sent()) {
+            header('HTTP/1.1 400 Bad request');
+        }
+
+        die('You have to provide invoiceId in query.');
+    }
+
+    public static function notFound(): void
+    {
+        if (! headers_sent()) {
+            header('HTTP/1.1 404 Not found');
+        }
+
+        die('Invoice not found.');
+    }
+
+    public static function forbidden(): void
+    {
+        if (! headers_sent()) {
+            header('HTTP/1.1 403 Forbidden');
+        }
+
+        die('You\'re not allowed to access this page.');
+    }
+}

--- a/plugins/invoice-qr-code/src/classes/QrPaymentFactory.php
+++ b/plugins/invoice-qr-code/src/classes/QrPaymentFactory.php
@@ -1,0 +1,108 @@
+<?php
+
+
+namespace App;
+
+use DateTimeImmutable;
+use Endroid\QrCode\QrCode;
+use InvalidArgumentException;
+use rikudou\CzQrPayment;
+use rikudou\EuQrPayment;
+use rikudou\SkQrPayment;
+
+class QrPaymentFactory
+{
+    private const EU_COUNTRIES_ISO_CODES = [
+        'BE',
+        'EL',
+        'LT',
+        'PT',
+        'BG',
+        'ES',
+        'LU',
+        'RO',
+        'CZ',
+        'FR',
+        'HU',
+        'SI',
+        'DK',
+        'HR',
+        'MT',
+        'SK',
+        'DE',
+        'IT',
+        'NL',
+        'FI',
+        'EE',
+        'CY',
+        'AT',
+        'SE',
+        'IE',
+        'LV',
+        'PL',
+        'UK',
+    ];
+
+    /** @var CountryConverter */
+    private $countryConverter;
+
+    public function __construct(CountryConverter $countryConverter)
+    {
+        $this->countryConverter = $countryConverter;
+    }
+
+
+    public function createQrCode(
+        int $countryId,
+        string $beneficiaryName,
+        string $bankAccountNumber,
+        string $bankRoutingCode,
+        string $variableSymbol,
+        string $amount,
+        string $currency,
+        DateTimeImmutable $dueDate
+    ): QrCode {
+        $countryIsoCode = $this->countryConverter->convertUcrmIdToISO($countryId);
+        $bankAccountNumberWithoutWhitespaces = preg_replace('/\s+/', '', $bankAccountNumber);
+
+        if ($countryIsoCode === 'CZ') {
+            $qrPayment = new CzQrPayment\QrPayment($bankAccountNumber, $bankRoutingCode);
+            $qrPayment
+                ->setVariableSymbol($variableSymbol)
+                ->setAmount($amount)
+                ->setCurrency($currency)
+                ->setDueDate($dueDate->format('Y-m-d'));
+
+            return $qrPayment->getQrImage();
+        }
+
+        if ($countryIsoCode === 'SK') {
+            $qrPayment = SkQrPayment\QrPayment::fromIBAN($bankAccountNumberWithoutWhitespaces);
+            $qrPayment
+                ->setSwift($bankRoutingCode)
+                ->setVariableSymbol($variableSymbol)
+                ->setAmount($amount)
+                ->setCurrency($currency)
+                ->setDueDate($dueDate->format('Y-m-d'));
+
+            return $qrPayment->getQrImage();
+        }
+
+        if (in_array($countryIsoCode, self::EU_COUNTRIES_ISO_CODES, true)) {
+            $payment = new EuQrPayment\QrPayment($bankAccountNumberWithoutWhitespaces);
+            $payment
+                ->setCharacterSet(EuQrPayment\Sepa\CharacterSet::UTF_8)
+                ->setBic($bankRoutingCode)
+                ->setBeneficiaryName($beneficiaryName)
+                ->setComment($variableSymbol)
+                ->setAmount(100)
+                ->setPurpose(EuQrPayment\Sepa\Purpose::INVOICE_PAYMENT)
+                ->setInformation('UCRM Invoice')
+                ->setCurrency($currency);
+
+            return $payment->getQrImage();
+        }
+
+        throw new InvalidArgumentException("QR Code generation is not supported for country $countryId ({$countryIsoCode}).");
+    }
+}

--- a/plugins/invoice-qr-code/src/classes/QrPaymentFactory.php
+++ b/plugins/invoice-qr-code/src/classes/QrPaymentFactory.php
@@ -43,66 +43,56 @@ class QrPaymentFactory
         'UK',
     ];
 
-    /** @var CountryConverter */
-    private $countryConverter;
-
-    public function __construct(CountryConverter $countryConverter)
-    {
-        $this->countryConverter = $countryConverter;
-    }
-
-
     public function createQrCode(
-        int $countryId,
+        string $countryIsoCode,
         string $beneficiaryName,
-        string $bankAccountNumber,
-        string $bankRoutingCode,
+        string $accountNumber,
+        string $routingNumber,
         string $variableSymbol,
         string $amount,
-        string $currency,
         DateTimeImmutable $dueDate
     ): QrCode {
-        $countryIsoCode = $this->countryConverter->convertUcrmIdToISO($countryId);
-        $bankAccountNumberWithoutWhitespaces = preg_replace('/\s+/', '', $bankAccountNumber);
+        $accountNumberWithoutWhitespaces = preg_replace('/\s+/', '', $accountNumber);
+        $routingNumberWithoutWhitespaces = preg_replace('/\s+/', '', $routingNumber);
 
         if ($countryIsoCode === 'CZ') {
-            $qrPayment = new CzQrPayment\QrPayment($bankAccountNumber, $bankRoutingCode);
+            $qrPayment = new CzQrPayment\QrPayment($accountNumberWithoutWhitespaces, $routingNumberWithoutWhitespaces);
             $qrPayment
                 ->setVariableSymbol($variableSymbol)
                 ->setAmount($amount)
-                ->setCurrency($currency)
+                ->setCurrency('CZK')
                 ->setDueDate($dueDate->format('Y-m-d'));
 
             return $qrPayment->getQrImage();
         }
 
         if ($countryIsoCode === 'SK') {
-            $qrPayment = SkQrPayment\QrPayment::fromIBAN($bankAccountNumberWithoutWhitespaces);
+            $qrPayment = SkQrPayment\QrPayment::fromIBAN($accountNumberWithoutWhitespaces);
             $qrPayment
-                ->setSwift($bankRoutingCode)
+                ->setSwift($routingNumberWithoutWhitespaces)
                 ->setVariableSymbol($variableSymbol)
                 ->setAmount($amount)
-                ->setCurrency($currency)
+                ->setCurrency('EUR')
                 ->setDueDate($dueDate->format('Y-m-d'));
 
             return $qrPayment->getQrImage();
         }
 
         if (in_array($countryIsoCode, self::EU_COUNTRIES_ISO_CODES, true)) {
-            $payment = new EuQrPayment\QrPayment($bankAccountNumberWithoutWhitespaces);
+            $payment = new EuQrPayment\QrPayment($accountNumberWithoutWhitespaces);
             $payment
                 ->setCharacterSet(EuQrPayment\Sepa\CharacterSet::UTF_8)
-                ->setBic($bankRoutingCode)
+                ->setBic($routingNumberWithoutWhitespaces)
                 ->setBeneficiaryName($beneficiaryName)
                 ->setComment($variableSymbol)
                 ->setAmount(100)
                 ->setPurpose(EuQrPayment\Sepa\Purpose::INVOICE_PAYMENT)
                 ->setInformation('UCRM Invoice')
-                ->setCurrency($currency);
+                ->setCurrency('EUR');
 
             return $payment->getQrImage();
         }
 
-        throw new InvalidArgumentException("QR Code generation is not supported for country $countryId ({$countryIsoCode}).");
+        throw new InvalidArgumentException("QR Code generation is not supported for country '{$countryIsoCode}'.");
     }
 }

--- a/plugins/invoice-qr-code/src/composer.json
+++ b/plugins/invoice-qr-code/src/composer.json
@@ -1,0 +1,20 @@
+{
+    "require": {
+        "ubnt/ucrm-plugin-sdk": "^0.5.2",
+        "rikudou/czqrpayment": "^4.0",
+        "endroid/qrcode": "^3.6",
+        "rikudou/skqrpayment": "^2.4",
+        "rikudou/euqrpayment": "^1.1",
+        "symfony/http-foundation": "^4.3"
+    },
+    "require-dev": {
+        "tracy/tracy": "^2.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": [
+                "classes/"
+            ]
+        }
+    }
+}

--- a/plugins/invoice-qr-code/src/composer.lock
+++ b/plugins/invoice-qr-code/src/composer.lock
@@ -1,0 +1,1434 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "eb8443c1d64c4ba7304ed09a1ae3fffc",
+    "packages": [
+        {
+            "name": "bacon/bacon-qr-code",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bacon/BaconQrCode.git",
+                "reference": "eaac909da3ccc32b748a65b127acd8918f58d9b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/eaac909da3ccc32b748a65b127acd8918f58d9b0",
+                "reference": "eaac909da3ccc32b748a65b127acd8918f58d9b0",
+                "shasum": ""
+            },
+            "require": {
+                "dasprid/enum": "^1.0",
+                "ext-iconv": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phly/keep-a-changelog": "^1.4",
+                "phpunit/phpunit": "^6.4",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "suggest": {
+                "ext-imagick": "to generate QR code images"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BaconQrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "http://www.dasprids.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "BaconQrCode is a QR code generator for PHP.",
+            "homepage": "https://github.com/Bacon/BaconQrCode",
+            "time": "2018-04-25T17:53:56+00:00"
+        },
+        {
+            "name": "dasprid/enum",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DASPRiD/Enum.git",
+                "reference": "631ef6e638e9494b0310837fa531bedd908fc22b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/631ef6e638e9494b0310837fa531bedd908fc22b",
+                "reference": "631ef6e638e9494b0310837fa531bedd908fc22b",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.4",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DASPRiD\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/"
+                }
+            ],
+            "description": "PHP 7.1 enum implementation",
+            "keywords": [
+                "enum",
+                "map"
+            ],
+            "time": "2017-10-25T22:45:27+00:00"
+        },
+        {
+            "name": "endroid/installer",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/endroid/installer.git",
+                "reference": "d4ae2bbd7977148dcb514ad625ece1a36f751a8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/endroid/installer/zipball/d4ae2bbd7977148dcb514ad625ece1a36f751a8b",
+                "reference": "d4ae2bbd7977148dcb514ad625ece1a36f751a8b",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1",
+                "php": ">=7.2"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                },
+                "class": "Endroid\\Installer\\Installer"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Endroid\\Installer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeroen van den Enden",
+                    "email": "info@endroid.nl"
+                }
+            ],
+            "time": "2019-03-30T21:42:01+00:00"
+        },
+        {
+            "name": "endroid/qrcode",
+            "version": "3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/endroid/qr-code.git",
+                "reference": "15641eec67291c6404b612694f65345c84a79919"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/endroid/qr-code/zipball/15641eec67291c6404b612694f65345c84a79919",
+                "reference": "15641eec67291c6404b612694f65345c84a79919",
+                "shasum": ""
+            },
+            "require": {
+                "bacon/bacon-qr-code": "^2.0",
+                "endroid/installer": "^1.1.5",
+                "ext-gd": "*",
+                "khanamiryan/qrcode-detector-decoder": "^1.0.2",
+                "myclabs/php-enum": "^1.5",
+                "php": ">=7.2",
+                "symfony/http-foundation": "^3.4|^4.0",
+                "symfony/options-resolver": "^3.4|^4.0",
+                "symfony/property-access": "^3.4|^4.0"
+            },
+            "require-dev": {
+                "endroid/test": "^1.1.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Endroid\\QrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeroen van den Enden",
+                    "email": "info@endroid.nl"
+                }
+            ],
+            "description": "Endroid QR Code",
+            "homepage": "https://github.com/endroid/qr-code",
+            "keywords": [
+                "bundle",
+                "code",
+                "endroid",
+                "php",
+                "qr",
+                "qrcode"
+            ],
+            "abandoned": "endroid/qr-code",
+            "time": "2019-05-25T20:13:40+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.4",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2018-04-22T15:46:56+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20T10:07:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "suggest": {
+                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2019-07-01T23:21:34+00:00"
+        },
+        {
+            "name": "khanamiryan/qrcode-detector-decoder",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/khanamiryan/php-qrcode-detector-decoder.git",
+                "reference": "a75482d3bc804e3f6702332bfda6cccbb0dfaa76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/khanamiryan/php-qrcode-detector-decoder/zipball/a75482d3bc804e3f6702332bfda6cccbb0dfaa76",
+                "reference": "a75482d3bc804e3f6702332bfda6cccbb0dfaa76",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6|^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Zxing\\": "lib/"
+                },
+                "files": [
+                    "lib/Common/customFunctions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ashot Khanamiryan",
+                    "email": "a.khanamiryan@gmail.com",
+                    "homepage": "https://github.com/khanamiryan",
+                    "role": "Developer"
+                }
+            ],
+            "description": "QR code decoder / reader",
+            "homepage": "https://github.com/khanamiryan/php-qrcode-detector-decoder/",
+            "keywords": [
+                "barcode",
+                "qr",
+                "zxing"
+            ],
+            "time": "2018-04-26T11:41:33+00:00"
+        },
+        {
+            "name": "myclabs/php-enum",
+            "version": "1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/php-enum.git",
+                "reference": "f46847626b8739de22e4ebc6b56010f317d4448d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/f46847626b8739de22e4ebc6b56010f317d4448d",
+                "reference": "f46847626b8739de22e4ebc6b56010f317d4448d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35|^5.7|^6.0",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MyCLabs\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP Enum contributors",
+                    "homepage": "https://github.com/myclabs/php-enum/graphs/contributors"
+                }
+            ],
+            "description": "PHP Enum implementation",
+            "homepage": "http://github.com/myclabs/php-enum",
+            "keywords": [
+                "enum"
+            ],
+            "time": "2019-05-05T10:12:03+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "rikudou/czqrpayment",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/RikudouSage/QrPaymentCZ.git",
+                "reference": "6decca1c5ef90ecb0af5db890d1a3bdc2e0f2bf5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/RikudouSage/QrPaymentCZ/zipball/6decca1c5ef90ecb0af5db890d1a3bdc2e0f2bf5",
+                "reference": "6decca1c5ef90ecb0af5db890d1a3bdc2e0f2bf5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "endroid/qr-code": "^3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "rikudou\\CzQrPayment\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Dominik Chrastecky",
+                    "email": "dominik@chrastecky.cz"
+                }
+            ],
+            "description": "QR payment library for Czech accounts",
+            "homepage": "https://github.com/RikudouSage/QrPaymentCZ",
+            "keywords": [
+                "payment",
+                "qr"
+            ],
+            "time": "2018-12-10T15:23:39+00:00"
+        },
+        {
+            "name": "rikudou/euqrpayment",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/RikudouSage/QrPaymentEU.git",
+                "reference": "4dc62e8c5759016f591da3e81a97547da53e0f15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/RikudouSage/QrPaymentEU/zipball/4dc62e8c5759016f591da3e81a97547da53e0f15",
+                "reference": "4dc62e8c5759016f591da3e81a97547da53e0f15",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "endroid/qr-code": "^3.2",
+                "friendsofphp/php-cs-fixer": "^2.13",
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpoffice/phpspreadsheet": "^1.5",
+                "phpstan/phpstan": "^0.11.1",
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "endroid/qr-code": "^3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "rikudou\\EuQrPayment\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Dominik Chrastecky",
+                    "email": "dominik@chrastecky.cz"
+                }
+            ],
+            "description": "QR payment library for European Union according to EPC standard version 2",
+            "homepage": "https://github.com/RikudouSage/QrPaymentEU",
+            "keywords": [
+                "payment",
+                "qr"
+            ],
+            "time": "2019-03-25T13:14:23+00:00"
+        },
+        {
+            "name": "rikudou/skqrpayment",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/RikudouSage/QrPaymentSK.git",
+                "reference": "88b04b88f4110481f500f67f27f19a1d8df1778e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/RikudouSage/QrPaymentSK/zipball/88b04b88f4110481f500f67f27f19a1d8df1778e",
+                "reference": "88b04b88f4110481f500f67f27f19a1d8df1778e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "endroid/qr-code": "^3.2",
+                "friendsofphp/php-cs-fixer": "^2.14",
+                "phpstan/phpstan": "^0.11.5",
+                "phpunit/phpunit": "^7"
+            },
+            "suggest": {
+                "endroid/qr-code": "^3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "rikudou\\SkQrPayment\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Dominik Chrastecky",
+                    "email": "dominik@chrastecky.cz"
+                }
+            ],
+            "description": "QR payment library for Slovak accounts",
+            "homepage": "https://github.com/RikudouSage/QrPaymentSK",
+            "keywords": [
+                "payment",
+                "qr"
+            ],
+            "time": "2019-04-03T16:42:32+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "b9896d034463ad6fd2bf17e2bf9418caecd6313d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b9896d034463ad6fd2bf17e2bf9418caecd6313d",
+                "reference": "b9896d034463ad6fd2bf17e2bf9418caecd6313d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-06-23T08:51:25+00:00"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "e1b507fcfa4e87d192281774b5ecd4265370180d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/e1b507fcfa4e87d192281774b5ecd4265370180d",
+                "reference": "e1b507fcfa4e87d192281774b5ecd4265370180d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/mime": "^4.3",
+                "symfony/polyfill-mbstring": "~1.1"
+            },
+            "require-dev": {
+                "predis/predis": "~1.0",
+                "symfony/expression-language": "~3.4|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpFoundation Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-06-26T09:25:00+00:00"
+        },
+        {
+            "name": "symfony/inflector",
+            "version": "v4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/inflector.git",
+                "reference": "889dc28cb6350ddb302fe9b8c796e4e6eb836856"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/inflector/zipball/889dc28cb6350ddb302fe9b8c796e4e6eb836856",
+                "reference": "889dc28cb6350ddb302fe9b8c796e4e6eb836856",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Inflector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Inflector Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "inflection",
+                "pluralize",
+                "singularize",
+                "string",
+                "symfony",
+                "words"
+            ],
+            "time": "2019-05-30T09:28:08+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "ec2c5565de60e03f33d4296a655e3273f0ad1f8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/ec2c5565de60e03f33d4296a655e3273f0ad1f8b",
+                "reference": "ec2c5565de60e03f33d4296a655e3273f0ad1f8b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.0",
+                "symfony/dependency-injection": "~3.4|^4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A library to manipulate MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "time": "2019-06-04T09:22:54+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "40762ead607c8f792ee4516881369ffa553fee6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/40762ead607c8f792ee4516881369ffa553fee6f",
+                "reference": "40762ead607c8f792ee4516881369ffa553fee6f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony OptionsResolver Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "time": "2019-06-13T11:01:17+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "c766e95bec706cdd89903b1eda8afab7d7a6b7af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/c766e95bec706cdd89903b1eda8afab7d7a6b7af",
+                "reference": "c766e95bec706cdd89903b1eda8afab7d7a6b7af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php72": "^1.9"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-03-04T13:44:35+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "ab50dcf166d5f577978419edd37aa2bb8eabce0c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/ab50dcf166d5f577978419edd37aa2bb8eabce0c",
+                "reference": "ab50dcf166d5f577978419edd37aa2bb8eabce0c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "symfony/property-access",
+            "version": "v4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "18ea48862a39e364927e71b9e4942af3c1a1cb8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/18ea48862a39e364927e71b9e4942af3c1a1cb8c",
+                "reference": "18ea48862a39e364927e71b9e4942af3c1a1cb8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/inflector": "~3.4|~4.0"
+            },
+            "require-dev": {
+                "symfony/cache": "~3.4|~4.0"
+            },
+            "suggest": {
+                "psr/cache-implementation": "To cache access methods."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PropertyAccess Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property path",
+                "reflection"
+            ],
+            "time": "2019-06-06T10:05:02+00:00"
+        },
+        {
+            "name": "ubnt/ucrm-plugin-sdk",
+            "version": "0.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ubiquiti-App/UCRM-Plugin-SDK.git",
+                "reference": "601cb1256e02bf54aff170aaf45d0470f2aaa8a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ubiquiti-App/UCRM-Plugin-SDK/zipball/601cb1256e02bf54aff170aaf45d0470f2aaa8a2",
+                "reference": "601cb1256e02bf54aff170aaf45d0470f2aaa8a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "~6.0",
+                "php": ">=7.1.0",
+                "symfony/filesystem": "^4.1"
+            },
+            "require-dev": {
+                "eloquent/phony-phpunit": "^4.0",
+                "eloquent/phpstan-phony": "^0.3.0",
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpstan/phpstan": "^0.10.5",
+                "phpstan/phpstan-strict-rules": "^0.10.1",
+                "phpunit/phpunit": "^7.4",
+                "symplify/easy-coding-standard": "^5.2"
+            },
+            "suggest": {
+                "ext-zip": "Needed for pack-plugin script."
+            },
+            "bin": [
+                "bin/pack-plugin"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ubnt\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "UCRM plugin SDK",
+            "homepage": "https://github.com/Ubiquiti-App/UCRM-Plugin-SDK",
+            "keywords": [
+                "sdk",
+                "ucrm"
+            ],
+            "time": "2019-06-24T12:06:31+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "tracy/tracy",
+            "version": "v2.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/tracy.git",
+                "reference": "7613eeff265b49a865add75360d1962449e3c12f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/tracy/zipball/7613eeff265b49a865add75360d1962449e3c12f",
+                "reference": "7613eeff265b49a865add75360d1962449e3c12f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-session": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/di": "^2.4 || ~3.0.0",
+                "nette/tester": "^2.2",
+                "nette/utils": "^2.4 || ^3.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "https://nette.org/donate": "Please support Tracy via a donation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src"
+                ],
+                "files": [
+                    "src/Tracy/shortcuts.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "😎 Tracy: the addictive tool to ease debugging PHP code for cool developers. Friendly design, logging, profiler, advanced features like debugging AJAX calls or CLI support. You will love it.",
+            "homepage": "https://tracy.nette.org",
+            "keywords": [
+                "Xdebug",
+                "debug",
+                "debugger",
+                "nette",
+                "profiler"
+            ],
+            "time": "2019-06-18T12:20:11+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/plugins/invoice-qr-code/src/main.php
+++ b/plugins/invoice-qr-code/src/main.php
@@ -1,0 +1,9 @@
+<?php
+
+chdir(__DIR__);
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+// Get UCRM log manager.
+$log = \Ubnt\UcrmPluginSdk\Service\PluginLogManager::create();
+$log->appendLog('Finished execution.');

--- a/plugins/invoice-qr-code/src/manifest.json
+++ b/plugins/invoice-qr-code/src/manifest.json
@@ -1,0 +1,15 @@
+{
+  "version": "1",
+  "information": {
+    "name": "invoice-qr-code",
+    "displayName": "Invoice QR code",
+    "description": "This plugin allows you to create invoices with QR codes containing payment information. It will help your customers pay you easily.",
+    "url": "https://github.com/Ubiquiti-App/UCRM-plugins",
+    "version": "1.0.0",
+    "ucrmVersionCompliancy": {
+      "min": "2.14.0-beta4",
+      "max": null
+    },
+    "author": "Jiri Travnicek"
+  }
+}

--- a/plugins/invoice-qr-code/src/public.php
+++ b/plugins/invoice-qr-code/src/public.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\CountryConverter;
+use App\Http;
+use App\QrPaymentFactory;
+use GuzzleHttp\Exception\RequestException;
+use Ubnt\UcrmPluginSdk\Security;
+use Ubnt\UcrmPluginSdk\Service;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+$pluginLogManager = Service\PluginLogManager::create();
+$api = Service\UcrmApi::create();
+$user = Service\UcrmSecurity::create()->getUser();
+
+// check that invoiceNumber is setr
+$invoiceId = $_GET['invoiceId'] ?? null;
+if ($invoiceId === null) {
+    $pluginLogManager->appendLog('Request was made with missing invoiceId. Have you configured the plugin correctly? See README.md.');
+    Http::badRequest();
+}
+
+// check that user is logged in and has permission to view invoices
+if ($user === null || !$user->hasViewPermission(Security\PermissionNames::BILLING_INVOICES)) {
+    Http::forbidden();
+}
+
+// load invoice from UCRM API
+try {
+    $invoice = $api->get("invoices/{$invoiceId}");
+} catch (RequestException $exception) {
+    $pluginLogManager->appendLog("Failed to load data for invoice {$invoiceId}.");
+    Http::notFound();
+}
+// check if user is client and if he's accessing his own invoice
+if ($user->isClient && $user->clientId !== $invoice['clientId']) {
+    Http::forbidden();
+}
+
+// create QrPayment object
+$qrPaymentFactory = new QrPaymentFactory(new CountryConverter($api));
+try {
+    $qrCode = $qrPaymentFactory->createQrCode(
+        $invoice['organizationCountryId'],
+        $invoice['organizationName'],
+        $invoice['organizationBankAccountField1'],
+        $invoice['organizationBankAccountField2'],
+        $invoice['number'],
+        $invoice['total'],
+        $invoice['currencyCode'],
+        new DateTimeImmutable($invoice['dueDate'])
+    );
+
+    // set correct headers and write image to output
+    header('Content-Type: ' . $qrCode->getContentType());
+    echo $qrCode->writeString();
+} catch (Exception $exception) {
+    $pluginLogManager->appendLog("Failed to generate QR code for invoice {$invoiceId} - {$exception->getMessage()}.");
+
+    // return 1x1 image because at this stage so client don't see errors instead of image.
+    // at this stage the plugin should be configured properly and template extended. something bad happened on UCRM API or plugin side
+    header('Content-Type: image/png');
+    echo base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=');
+}

--- a/plugins/invoice-qr-code/src/public.php
+++ b/plugins/invoice-qr-code/src/public.php
@@ -27,6 +27,7 @@ if ($user === null || !$user->hasViewPermission(Security\PermissionNames::BILLIN
 
 // load invoice from UCRM API
 try {
+    $invoiceId = $api->get("invoices?number={$invoiceId}")[0]['id']; // TODO remove this single line when invoice.id become available in invoice templates
     $invoice = $api->get("invoices/{$invoiceId}");
 } catch (RequestException $exception) {
     $pluginLogManager->appendLog("Failed to load data for invoice {$invoiceId}.");

--- a/plugins/invoice-qr-code/src/public.php
+++ b/plugins/invoice-qr-code/src/public.php
@@ -1,55 +1,38 @@
 <?php
 
 use App\CountryConverter;
-use App\Http;
 use App\QrPaymentFactory;
-use GuzzleHttp\Exception\RequestException;
-use Ubnt\UcrmPluginSdk\Security;
 use Ubnt\UcrmPluginSdk\Service;
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-$pluginLogManager = Service\PluginLogManager::create();
-$api = Service\UcrmApi::create();
-$user = Service\UcrmSecurity::create()->getUser();
-
-// check that invoiceNumber is setr
-$invoiceId = $_GET['invoiceId'] ?? null;
-if ($invoiceId === null) {
-    $pluginLogManager->appendLog('Request was made with missing invoiceId. Have you configured the plugin correctly? See README.md.');
-    Http::badRequest();
-}
-
-// check that user is logged in and has permission to view invoices
-if ($user === null || !$user->hasViewPermission(Security\PermissionNames::BILLING_INVOICES)) {
-    Http::forbidden();
-}
-
-// load invoice from UCRM API
 try {
-    $invoiceId = $api->get("invoices?number={$invoiceId}")[0]['id']; // TODO remove this single line when invoice.id become available in invoice templates
-    $invoice = $api->get("invoices/{$invoiceId}");
-} catch (RequestException $exception) {
-    $pluginLogManager->appendLog("Failed to load data for invoice {$invoiceId}.");
-    Http::notFound();
-}
-// check if user is client and if he's accessing his own invoice
-if ($user->isClient && $user->clientId !== $invoice['clientId']) {
-    Http::forbidden();
-}
+    $pluginLogManager = Service\PluginLogManager::create();
+    $api = Service\UcrmApi::create();
+    $user = Service\UcrmSecurity::create()->getUser();
 
-// create QrPayment object
-$qrPaymentFactory = new QrPaymentFactory(new CountryConverter($api));
-try {
+    // TODO all parameters should be fetched from API by invoice id
+    $organizationCountry = $_GET['organizationCountry'] ?? null; // {{ organization.country }}
+    $organizationName = $_GET['organizationName'] ?? null; // {{ organization.name }}
+    $bankAccount = $_GET['bankAccount'] ?? null; // {{ organization.bankAccount }}
+    $invoiceNumber = $_GET['invoiceNumber'] ?? null; // {{ invoice.number }}
+    $amountDue = $_GET['amountDue'] ?? null; // {{ totals.amountDue }}
+    $dueDate = $_GET['dueDate'] ?? null; // {{ invoice.dueDate }}
+
+    $organizationCountryIsoCode = (new CountryConverter($api))->convertCountryNameToISO($organizationCountry);
+    [$accountNumber, $routingNumber] = explode('/', $bankAccount);
+    $amountDue = (float) filter_var($amountDue, FILTER_SANITIZE_NUMBER_FLOAT) / 100;
+
+    // create QrPayment object
+    $qrPaymentFactory = new QrPaymentFactory();
     $qrCode = $qrPaymentFactory->createQrCode(
-        $invoice['organizationCountryId'],
-        $invoice['organizationName'],
-        $invoice['organizationBankAccountField1'],
-        $invoice['organizationBankAccountField2'],
-        $invoice['number'],
-        $invoice['total'],
-        $invoice['currencyCode'],
-        new DateTimeImmutable($invoice['dueDate'])
+        $organizationCountryIsoCode,
+        $organizationName,
+        $accountNumber,
+        $routingNumber,
+        $invoiceNumber,
+        $amountDue,
+        new DateTimeImmutable($dueDate)
     );
 
     // set correct headers and write image to output
@@ -58,7 +41,16 @@ try {
     header('content-length: ' . strlen($imageString));
     echo $imageString;
 } catch (Exception $exception) {
-    $pluginLogManager->appendLog("Failed to generate QR code for invoice {$invoiceId} - {$exception->getMessage()}.");
+    $pluginLogManager->appendLog("Failed to generate QR code for invoice {$invoiceNumber} - {$exception->getMessage()}. Parameters - " . json_encode([
+        'organizationCountry' => $organizationCountry,
+        'organizationCountryIsoCode' => $organizationCountryIsoCode,
+        'organizationName' => $organizationName,
+        'accountNumber' => $accountNumber ?? null,
+        'routingNumber' => $routingNumber ?? null,
+        'invoiceNumber' => $invoiceNumber,
+        'amountDue' => $amountDue,
+        'dueDate' => $dueDate,
+    ]));
 
     // return 1x1 image because at this stage so client don't see errors instead of image.
     // at this stage the plugin should be configured properly and template extended. something bad happened on UCRM API or plugin side

--- a/plugins/invoice-qr-code/src/public.php
+++ b/plugins/invoice-qr-code/src/public.php
@@ -53,8 +53,10 @@ try {
     );
 
     // set correct headers and write image to output
-    header('Content-Type: ' . $qrCode->getContentType());
-    echo $qrCode->writeString();
+    $imageString = $qrCode->writeString();
+    header('content-type: ' . $qrCode->getContentType());
+    header('content-length: ' . strlen($imageString));
+    echo $imageString;
 } catch (Exception $exception) {
     $pluginLogManager->appendLog("Failed to generate QR code for invoice {$invoiceId} - {$exception->getMessage()}.");
 


### PR DESCRIPTION
Works only with organizations in Czech Republic and Slovakia because `{{ totals.amountDue }}` is formatted by country and for this demo it has no sence to support all formattings.

There are two options how could we improve quality of this plugin:
1) add `{{ invoice.id }}` placeholder and use UCRM API to fetch all invoice information. also there must be some kind of "api key" to protect the `public.php` from scrapping. this behavior was reverted in commit 3a5e4b6229612f987796a07034e047d673a7865c
2) add placeholders with raw data which are necessary to generate payment QR