### PR TITLE
Routeros-suspension: fix a deprecated method and suspend all statuses of suspended services

### DIFF
--- a/plugins/routeros-suspension/src/src/Service/RouterOsApi.php
+++ b/plugins/routeros-suspension/src/src/Service/RouterOsApi.php
@@ -35,7 +35,7 @@ class RouterOsApi
 
     public function print(string $endpoint): array
     {
-        return $this->getClient()->write(new Query(sprintf('%s/print', $endpoint)))->read();
+        return $this->getClient()->query(new Query(sprintf('%s/print', $endpoint)))->read();
     }
 
     public function remove(string $endpoint, array $ids): array
@@ -47,7 +47,7 @@ class RouterOsApi
         $query = (new Query(sprintf('%s/remove', $endpoint)))
             ->add(sprintf('=.id=%s', implode(',', $ids)));
 
-        return $this->getClient()->write($query)->read();
+        return $this->getClient()->query($query)->read();
     }
 
     public function add(string $endpoint, array $sentences, string $commentPrefix = 'ucrm_'): void
@@ -68,7 +68,7 @@ class RouterOsApi
                 $query->add(sprintf('=%s=%s', $key, $item));
             }
 
-            $this->getClient()->write($query)->read();
+            $this->getClient()->query($query)->read();
         }
     }
 

--- a/plugins/routeros-suspension/src/src/Service/Suspender.php
+++ b/plugins/routeros-suspension/src/src/Service/Suspender.php
@@ -15,7 +15,7 @@ class Suspender
 
     private const COMMENT_SIGNATURE = 'ucrm_';
 
-    private const SERVICE_STATUS_ACTIVE = 3;
+    private const SERVICE_STATUS_ACTIVE = [2, 3, 4, 5, 6, 7, 8];
 
     /**
      * @var UcrmApi
@@ -261,7 +261,7 @@ class Suspender
         return $this->ucrmApi->get(
             'clients/services',
             [
-                'statuses' => [self::SERVICE_STATUS_ACTIVE],
+                'statuses' => self::SERVICE_STATUS_ACTIVE,
             ]
         );
     }


### PR DESCRIPTION
The write method was changed in the RouterOSApi.php file, which was declared obsolete and removed from the library. Instead it was replaced by the query method. In addition, other statuses of suspended services were added.